### PR TITLE
Add dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Helm Repo Push
-A Drone.io plugin for packaging and pushing a helm chart to a charmuseum repo.
+A Drone.io plugin for packaging and pushing a helm chart to a chartmuseum repo.
 
 example usage:
 
@@ -21,5 +21,4 @@ helm_chart_build:
 1. This plugin is specifically built to push to a chartmuseum repo using curl.
 1. helm_repo_url is a secret in case it requires basic auth.
 1. This plugin expects your chart to be inside a directory at `repo_name`.
-
-
+1. By default, this plugin will update dependencies unless the environment variable UPDATE_DEPENDENCIES=false.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ helm_chart_build:
   image: gmorse81/helm-repo-push
   repo_name: my-helm-repo-alias
   chart_subdir: name-of-chart
+  update_dependencies: "true"
   secrets: [ helm_repo_url ]
   when:
     event: [pull_request, push]
@@ -21,4 +22,4 @@ helm_chart_build:
 1. This plugin is specifically built to push to a chartmuseum repo using curl.
 1. helm_repo_url is a secret in case it requires basic auth.
 1. This plugin expects your chart to be inside a directory at `repo_name`.
-1. By default, this plugin will update dependencies unless the environment variable UPDATE_DEPENDENCIES=false.
+1. By default, this plugin will update dependencies unless the environment variable PLUGIN_UPDATE_DEPENDENCIES="false".

--- a/repo-push.sh
+++ b/repo-push.sh
@@ -2,7 +2,12 @@
 
 helm init --client-only
 helm repo add ${PLUGIN_REPO_NAME} ${HELM_REPO_URL}
-helm package -u --version=$(cat .tags) --app-version=$(cat .tags) --save=false ${PLUGIN_CHART_SUBDIR}/.
+echo ${UPDATE_DEPENDENCIES}
+if [ "${UPDATE_DEPENDENCIES}" = "false" ]; then
+  helm package --version=$(cat .tags) --app-version=$(cat .tags) --save=false ${PLUGIN_CHART_SUBDIR}/.
+else
+  helm package -u --version=$(cat .tags) --app-version=$(cat .tags) --save=false ${PLUGIN_CHART_SUBDIR}/.
+fi
 RESPONSE=$(curl --data-binary "@${PLUGIN_CHART_SUBDIR}-$(cat .tags).tgz" ${HELM_REPO_URL}/api/charts)
 echo $RESPONSE
 if [ $RESPONSE = '{"saved":true}' ]; then

--- a/repo-push.sh
+++ b/repo-push.sh
@@ -2,8 +2,7 @@
 
 helm init --client-only
 helm repo add ${PLUGIN_REPO_NAME} ${HELM_REPO_URL}
-echo ${UPDATE_DEPENDENCIES}
-if [ "${UPDATE_DEPENDENCIES}" = "false" ]; then
+if [ "${PLUGIN_UPDATE_DEPENDENCIES}" = "false" ]; then
   helm package --version=$(cat .tags) --app-version=$(cat .tags) --save=false ${PLUGIN_CHART_SUBDIR}/.
 else
   helm package -u --version=$(cat .tags) --app-version=$(cat .tags) --save=false ${PLUGIN_CHART_SUBDIR}/.


### PR DESCRIPTION
Adds a check to see if the environment variable UPDATE_DEPENDENCIES is set to "false". If it is, dependencies won't be updated. If it's not set or equals anything else besides "false", dependencies will be updated as they are before this commit.